### PR TITLE
fix:랜덤 포인트 트리거 버그 수정

### DIFF
--- a/src/app/home/page.jsx
+++ b/src/app/home/page.jsx
@@ -24,7 +24,7 @@ export default async function HomePage({ searchParams }) {
         <div className="hidden md:block w-full h-0.5 bg-gray-100" />
       </div>
       <RandomPointHomeTrigger>
-        <RandomPoint />
+        {({ onClose }) => <RandomPoint onClose={onClose} />}
       </RandomPointHomeTrigger>
       <div>
         <BaseCardsSection grade={grade} genre={genre} sale={sale} />

--- a/src/components/RandomPoint.jsx
+++ b/src/components/RandomPoint.jsx
@@ -7,7 +7,7 @@ import { IoMdClose } from "react-icons/io";
 import Image from "next/image";
 import { useState, useEffect } from "react";
 
-export default function RandomPoint() {
+export default function RandomPoint({ onClose }) {
   const [selectedIndex, setSelectedIndex] = useState(null);
   const [active, setActive] = useState(false);
   const [closed, setClosed] = useState(true);
@@ -29,6 +29,7 @@ export default function RandomPoint() {
   };
 
   const handleClose = () => {
+    if (onClose) onClose();
     setClosed(false);
   };
 

--- a/src/components/RandomPointHomeTrigger.jsx
+++ b/src/components/RandomPointHomeTrigger.jsx
@@ -52,6 +52,8 @@ export default function RandomPointHomeTrigger({ children }) {
 
   if (!show || loading) return null;
   return (
-    <div style={{ zIndex: 99999, position: "fixed", inset: 0 }}>{children}</div>
+    <div style={{ zIndex: 99999, position: "fixed", inset: 0 }}>
+      {children && children({ onClose: () => setShow(false) })}
+    </div>
   );
 }


### PR DESCRIPTION
# PR 유형 (x로 선택)

- [ ] `feat:` 새로운 기능을 추가
- [x] `fix:` 버그를 수정한 커밋
- [ ] `docs:` 문서 관련 수정
- [ ] `style:` 코드 스타일 관련 수정 (기능 변화 없음)
- [ ] `refactor:` 코드 리팩토링 (기능 변화 없음)

---

## 설명

랜덤 포인트 홈 트리거가 랜덤 포인트 모달 종료시 같이 사라지지 않고 새로고침해야 하는 버그 수정

---

## 상세 작업 내용


- 랜덤 포인트 홈 트리거 에서 모달의 닫힘 상태를 관리 하기 위해 children({ onClose: () => setShow(false) })} 추가
- 페이지에서 절달을 위해 props로 onClose 전달
- 랜덤 포인트 닫힘 상태 변경을 위해 랜덤포인트 모달에 handleClose추가

---

## 리뷰

-
-
